### PR TITLE
fix: populate assets directory before migrate-job

### DIFF
--- a/erpnext/templates/job-migrate-sites.yaml
+++ b/erpnext/templates/job-migrate-sites.yaml
@@ -22,6 +22,14 @@ spec:
         volumeMounts:
           - name: sites-dir
             mountPath: "/data"
+      - name: populate-assets
+        image: "{{ .Values.nginxImage.repository }}:{{ .Values.nginxImage.tag }}"
+        command: ["/bin/bash", "-c"]
+        args:
+          - "rsync -a --delete /var/www/html/assets/frappe /assets"
+        volumeMounts:
+          - name: assets-cache
+            mountPath: /assets
       {{- if .Values.migrateJob.backup }}
       - name: backup
         image: "{{ .Values.pythonImage.repository }}:{{ .Values.pythonImage.tag }}"


### PR DESCRIPTION
populate node_modules and frappe assets before migrate job